### PR TITLE
无onRequest 请求头参数不设置优化

### DIFF
--- a/src/xhr-proxy.js
+++ b/src/xhr-proxy.js
@@ -216,7 +216,7 @@ function Proxy(proxy) {
         setRequestHeader: function (args, xhr) {
             // Collect request headers
             xhr.config.headers[args[0].toLowerCase()] = args[1];
-            return true;
+            // return true;
         },
         addEventListener: function (args, xhr) {
             var _this = this;

--- a/src/xhr-proxy.js
+++ b/src/xhr-proxy.js
@@ -216,7 +216,7 @@ function Proxy(proxy) {
         setRequestHeader: function (args, xhr) {
             // Collect request headers
             xhr.config.headers[args[0].toLowerCase()] = args[1];
-            // return true;
+            return !!onRequest;
         },
         addEventListener: function (args, xhr) {
             var _this = this;


### PR DESCRIPTION
proxy 不传onRequest时底层的请求头参数不设置