### PR TITLE
fix: events handling

### DIFF
--- a/src/xhr-proxy.js
+++ b/src/xhr-proxy.js
@@ -27,7 +27,7 @@ function trim(str) {
 }
 
 function getEventTarget(xhr) {
-  return xhr.watcher || (xhr.watcher = document.createElement('a'));
+  return xhr.watcher || (xhr.watcher = typeof document.createDocumentFragment === 'function' ? document.createDocumentFragment() : document.createElement('a'));
 }
 
 function triggerListener(xhr, name) {
@@ -157,6 +157,9 @@ function proxyAjax(proxy, win) {
     return true;
   }
 
+  var eventListenerFnMap = typeof WeakMap === 'function' ? function (_this) {
+    return _this.eventListenerFnMap || (_this.eventListenerFnMap = new WeakMap());
+  } : null;
 
   var { originXhr, unHook } =  hook({
     onload: preventXhrProxyCallback,
@@ -210,16 +213,36 @@ function proxyAjax(proxy, win) {
       if (onRequest) return true;
     },
     addEventListener: function (args, xhr) {
+      // args = (type:string , listener: EventListener, opt: any?)
       var _this = this;
       if (events.indexOf(args[0]) !== -1) {
         var handler = args[1];
-        getEventTarget(xhr).addEventListener(args[0], function (e) {
+        var Gn = function (e) {
           var event = configEvent(e, _this);
-          event.type = args[0];
+          event.type = e.type;
           event.isTrusted = true;
           handler.call(_this, event);
-        });
+        };
+        if (eventListenerFnMap) {
+          var map = eventListenerFnMap(_this);
+          map.set(handler, Gn);
+        }
+        getEventTarget(xhr).addEventListener(args[0], Gn, false);
         return true;
+      }
+    },
+    removeEventListener: function (args, xhr) {
+      // args = (type:string , listener: EventListener, opt: any?)
+      if (events.indexOf(args[0]) !== -1) {
+        var handler = args[1];
+        if (eventListenerFnMap) {
+          var map = eventListenerFnMap(this);
+          var Gn = map.get(handler);
+          if (Gn) {
+            getEventTarget(xhr).removeEventListener(args[0], Gn, false);
+            return true;
+          }
+        }
       }
     },
     getAllResponseHeaders: function (_, xhr) {


### PR DESCRIPTION
### `getEventTarget(xhr)`
* only `document.createElement('a')` was used.
* `document.createDocumentFragment()` would be a better way to create EventTarget since the creation of HTMLElement is slightly higher than `DocumentFragment`
* [`document.createDocumentFragment()` is well supported in ES5](https://caniuse.com/?search=document.createDocumentFragment). (just Opera 10-12 is unknown)
* No functional affect to the current script.

### addEventListener and removeEventListener
* `removeEventListener` was missing, but mentioned in `index.d.ts`
* `WeakMap` is used for this particular usage.
* `WeakMap` in very old browsers might be not supported, in that case, `removeEventListener` is ignored.
* No functional affect to the current script.

### Minor fix in event handler
* ~changed `event.type = args[0];` to `event.type = e.type;` to avoid memory leakage of array `args`.~ the type must be the same as the `args[0]`. assignment not required.