### PR TITLE
Bug Fix for `responseType = 'json'` (`responseData`)

### DIFF
--- a/src/xhr-proxy.js
+++ b/src/xhr-proxy.js
@@ -106,29 +106,31 @@ function proxyAjax(proxy, win) {
     onResponse = proxy.onResponse,
     onError = proxy.onError;
 
+  function getResponseData(xhrProxy) {
+    var responseType = xhrProxy.responseType;
+    if (!responseType || responseType === 'text') {
+      return xhrProxy.responseText;
+    }
+    // reference: https://shanabrian.com/web/html-css-js-technics/js-ie10-ie11-xhr-json-string.php
+    // reference: https://github.com/axios/axios/issues/2390
+    // json - W3C standard - xhrProxy.response = JSON object; responseText is unobtainable
+    // For details, see https://github.com/wendux/ajax-hook/issues/117
+    // IE 9, 10 & 11 - only responseText
+    var response = xhrProxy.response;
+    if (responseType === 'json' && !response) {
+      try {
+        return JSON.parse(xhrProxy.responseText);
+      } catch (e) {
+        console.warn(e);
+      }
+    }
+    return response;
+  };
+
   function handleResponse(xhr, xhrProxy) {
     var handler = new ResponseHandler(xhr);
-    var getResponseData = function () {
-      var responseType = xhrProxy.responseType;
-      if (!responseType || responseType === 'text') {
-        return xhrProxy.responseText;
-      }
-      // reference: https://shanabrian.com/web/html-css-js-technics/js-ie10-ie11-xhr-json-string.php
-      // reference: https://github.com/axios/axios/issues/2390
-      // json - W3C standard - xhrProxy.response = JSON object; responseText is unobtainable
-      // For details, see https://github.com/wendux/ajax-hook/issues/117
-      // IE 9, 10 & 11 - only responseText
-      if (responseType === 'json' && xhrProxy.readyState === 4 && xhrProxy.status !== 0 && !xhrProxy.response) {
-        try {
-          return JSON.parse(xhrProxy.responseText);
-        } catch (e) {
-          console.warn(e);
-        }
-      }
-      return xhrProxy.response;
-    }; //ie9
     var ret = {
-      response: getResponseData(),
+      response: getResponseData(xhrProxy),
       status: xhrProxy.status,
       statusText: xhrProxy.statusText,
       config: xhr.config,

--- a/src/xhr-proxy.js
+++ b/src/xhr-proxy.js
@@ -108,25 +108,38 @@ function proxyAjax(proxy, win) {
 
   function handleResponse(xhr, xhrProxy) {
     var handler = new ResponseHandler(xhr);
+    var getResponseData = function () {
+      // object getter is part of ES5
+      // getter to avoid uncessary processing. only proceed if response.response is called.
+      // property 'response' is enumerable such that JSON.stringify(response) contains response
+      var responseType = xhrProxy.responseType;
+      if (!responseType || responseType === 'text') {
+        return xhrProxy.responseText;
+      }
+      // reference: https://shanabrian.com/web/html-css-js-technics/js-ie10-ie11-xhr-json-string.php
+      // reference: https://github.com/axios/axios/issues/2390
+      // json - W3C standard - xhrProxy.response = JSON object; responseText is unobtainable
+      // For details, see https://github.com/wendux/ajax-hook/issues/117
+      // IE 9, 10 & 11 - only responseText
+      if (responseType === 'json' && typeof JSON === 'object' && ((navigator || 0).userAgent || '').indexOf('Trident') !== -1) {
+        return JSON.parse(xhrProxy.responseText);
+      }
+      return xhrProxy.response;
+    }; //ie9
+    var responseData;
     var ret = {
       get response() {
-        // object getter is part of ES5
-        // getter to avoid uncessary processing. only proceed if response.response is called.
-        // property 'response' is enumerable such that JSON.stringify(response) contains response
-        var responseType = xhrProxy.responseType;
-        if (!responseType || responseType === 'text') {
-          return xhrProxy.responseText;
+        if (getResponseData) {
+          responseData = getResponseData();
+          getResponseData = null;
         }
-        // reference: https://shanabrian.com/web/html-css-js-technics/js-ie10-ie11-xhr-json-string.php
-        // reference: https://github.com/axios/axios/issues/2390
-        // json - W3C standard - xhrProxy.response = JSON object; responseText is unobtainable
-        // For details, see https://github.com/wendux/ajax-hook/issues/117
-        // IE 9, 10 & 11 - only responseText
-        if (responseType === 'json' && typeof JSON === 'object' && ((navigator || 0).userAgent || '').indexOf('Trident') !== -1) {
-          return JSON.parse(xhrProxy.responseText);
-        }
-        return xhrProxy.response;
-      }, //ie9
+        return responseData;
+      },
+      set response(nv) {
+        getResponseData = null;
+        responseData = nv;
+        return true;
+      },
       status: xhrProxy.status,
       statusText: xhrProxy.statusText,
       config: xhr.config,


### PR DESCRIPTION
close #117; close #93 

# Bug Description
Error throws when `responseType` is `json`. See #117 #93 

# Root Cause 
`responseData` was wrongly set to `xhrProxy.responseText` for `responseType === 'json'`
```js
var responseData = !responseType || responseType === 'text' || responseType === 'json' ?		
      xhrProxy.responseText : xhrProxy.response;
```

# Detail
`responseType: json` is first introduced by Blink in Dec 2011. ([Source](https://lists.w3.org/Archives/Public/public-webapps/2011OctDec/1326.html))
`responseType: moz-json` was added in Fx 9 and then removed in Fx 10.

As the type suggested, `json` means the response data is already JSON object, and such that `xhrProxy.response` shall be used in the response. (i.e. no need to `JSON.parse(responseText)`)

Starting from 2020 (Source: TBC), `responseText` will no longer be available in Blink, and calling getter of `xhr.responseText` will directly throw an Error.


--------------------

`responseType: json` 首次由Blink在2011年12月引入。([来源](https://lists.w3.org/Archives/Public/public-webapps/2011OctDec/1326.html))
`responseType: moz-json` 在Fx 9中添加，然后在Fx 10中被移除。

正如其名称所示，`json` 表示响应数据已经是JSON对象，因此应在响应中使用 `xhrProxy.response`。（即不需要 `JSON.parse(responseText)`）

从2020年开始（来源：待定），在Blink中将不再提供 `responseText`，调用 `xhr.responseText` 的getter将直接抛出错误。



# Impact

The response will be changed to JSON object instead of text if the responseType is `json`.
This will change the `onResponse(response, handler)` that the `response.response` is json not text.
If we are keeping the old behavior, `response = JSON.stringify(responseData)` in `handleResponse(xhr, xhrProxy)` and then `jsonResponse = JSON.parse(response.response)` in `onResponse(response, handler)` which is very stupid.

--------------------

如果`responseType`为`json`，响应将被更改为JSON对象，而不是文本。
这将会改变`onResponse(response, handler)`，使得`response.response`是JSON格式而不是文本。
如果我们要保持旧的行为，在`handleResponse(xhr，xhrProxy)`中使用`response = JSON.stringify(responseData)`，然后在`onResponse(response，handler)`中使用`jsonResponse = JSON.parse(response.response)`，这是非常愚蠢的。